### PR TITLE
Fix/typ

### DIFF
--- a/src/proto-types-gen/src/tendermint/crypto/proof.ts
+++ b/src/proto-types-gen/src/tendermint/crypto/proof.ts
@@ -26,7 +26,7 @@ export interface DominoOp {
 
 /**
  * ProofOp defines an operation used for calculating Merkle root
- * The data could be arbitrary format, providing nessecary data
+ * The data could be arbitrary format, providing necessary data
  * for example neighbouring node hash
  */
 export interface ProofOp {

--- a/src/proto-types-gen/third_party/proto/confio/proofs.proto
+++ b/src/proto-types-gen/third_party/proto/confio/proofs.proto
@@ -42,7 +42,7 @@ enum LengthOp {
 
 /**
 ExistenceProof takes a key and a value and a set of steps to perform on it.
-The result of peforming all these steps will provide a "root hash", which can
+The result of performing all these steps will provide a "root hash", which can
 be compared to the value in a header.
 
 Since it is computationally infeasible to produce a hash collission for any of the used


### PR DESCRIPTION
# Fix: Corrected typo errors in generated proto files

## What was changed
1. **Corrected typos**:
   - Replaced `nessecary` with `necessary` in `src/proto-types-gen/src/tendermint/crypto/proof.ts`.
   - Replaced `peforming` with `performing` in `src/proto-types-gen/third_party/proto/confio/proofs.proto`.

## Why these changes were made
- **Fixing typos** improves clarity and professionalism within the codebase, ensuring correctness and readability.
- Correcting generated files helps maintain consistency and avoids confusion for developers working with these definitions.

## Additional Notes
- These changes focus purely on fixing typographical errors without impacting functionality.
